### PR TITLE
Makes theme extendable

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,12 +47,33 @@ In addition to importing oceanwind to generate class names for given shorthand. 
 - The Tailwind reset [available here](https://unpkg.com/tailwindcss@1.7.5/dist/base.min.css)
 - The Tailwind prose helper [available here](https://unpkg.com/@tailwindcss/typography@0.2.0/dist/typography.min.css)
 
+### Extending the default theme
+
+Importing and invoking oceanwind directly will cause it to refer to the [default theme](https://github.com/lukejacksonn/oceanwind/blob/master/core/theme.js) for directives that require themed values (like `bg-red-500` for example). If you would like to customize the theme then used the `themed` export instead of the default export.
+
+```js
+import { themed } from 'https://unpkg.com/oceanwind';
+
+const ow = themed({
+  colors: {
+    red: {
+      500: 'hotpink',
+    },
+  },
+});
+
+ow`bg-red-500`; // will result in a hotpink background-color
+```
+
+Any custom theme provided to the `themed` function will be deep merged with the default theme.
+
 ## Example
 
 Most of the time developers will be using a front end framework to render DOM elements. Oceanwind is framework agnostic but here is an example of how you might use it with preact and no build step.
 
 ```js
 import { render, h } from 'https://unpkg.com/preact?module';
+
 import htm from 'https://unpkg.com/htm?module';
 import ow from 'https://unpkg.com/oceanwind';
 

--- a/core/theme.js
+++ b/core/theme.js
@@ -76,6 +76,7 @@ export default {
   },
 
   screen: {
+    xs: '480px',
     sm: '640px',
     md: '768px',
     lg: '1024px',

--- a/index.js
+++ b/index.js
@@ -1,9 +1,9 @@
 import translate from './core/translate.js';
-import theme from './core/theme.js';
+import defaultTheme from './core/theme.js';
 import merge from './util/merge.js';
 import { css } from './util/otion.js';
 
-export default ([rules]) => {
+export const process = (theme) => ([rules]) => {
   // Keep track of processed rules
   const seen = {};
   // Go through each rule in the array and translate to css
@@ -37,5 +37,14 @@ export default ([rules]) => {
       return translation;
     });
   // Return class names for styles
-  return css(merge(...styles));
+  return merge(...styles);
 };
+
+// If passed a theme then return process primed with merged themes
+export const themed = (input) => {
+  const theme = merge(defaultTheme, input);
+  return (input) => css(process(theme)(input));
+};
+
+// If passed a tagged template then process with the default theme
+export default (input) => css(process(defaultTheme)(input));

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "main": "index.js",
   "scripts": {
     "start": "servor --browse --reload --editor",
-    "build": "esbuild --bundle index.js --outfile=index.min.js --format=esm --minify"
+    "build": "esbuild --bundle index.js --outfile=index.min.js --format=esm --minify",
+    "prepublish": "npm run build"
   },
   "keywords": [],
   "author": "Luke Jackson (@lukejacksonn)",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oceanwind",
-  "version": "0.1.3",
+  "version": "0.2.0",
   "description": "compiles tailwind like shorthand syntax into css at runtime",
   "module": "index.js",
   "main": "index.js",

--- a/test/app.js
+++ b/test/app.js
@@ -1,9 +1,17 @@
 import { render, h } from 'https://unpkg.com/preact?module';
 import htm from 'https://unpkg.com/htm?module';
 
-import ow from '../index.js';
+import { themed } from '../index.js';
 
 const html = htm.bind(h);
+
+const ow = themed({
+  colors: {
+    purple: {
+      800: 'hotpink',
+    },
+  },
+});
 
 const style = {
   main: ow`

--- a/test/module.js
+++ b/test/module.js
@@ -1,5 +1,5 @@
-import translate from '../core/translate.js';
 import theme from '../core/theme.js';
+import { process } from '../index.js';
 
 const cases = {
   hidden: { display: 'none' },
@@ -560,8 +560,8 @@ const test = Object.entries(cases).reduce(
     [i]: {
       input: i,
       expected: o,
-      actual: translate(theme)(i),
-      passed: JSON.stringify(translate(theme)(i)) === JSON.stringify(o),
+      actual: process(theme)([i]),
+      passed: JSON.stringify(process(theme)([i])) === JSON.stringify(o),
     },
   }),
   {}
@@ -570,4 +570,18 @@ const test = Object.entries(cases).reduce(
 console.log({
   failed: Object.values(test).filter((x) => !x.passed),
   passed: Object.values(test).filter((x) => x.passed),
+});
+
+const themed = process({
+  colors: {
+    red: {
+      500: 'hotpink',
+    },
+  },
+});
+
+console.log({
+  themed:
+    JSON.stringify(themed`bg-red-500`) ===
+    JSON.stringify({ 'background-color': 'hotpink' }),
 });


### PR DESCRIPTION
Provide a `themed` export that primes the process function with the default theme deep merged with any provided custom theme. For example:

```js
import { themed } from 'https://unpkg.com/oceanwind';

const ow = themed({
  colors: {
    red: {
      500: 'hotpink',
    },
  },
});

ow`bg-red-500`; // will result in a hotpink background-color
```

Also makes the `process` function pure(er) by detaching it from the call to `otion`. This makes testing a bit easier.