### PR TITLE
Variant grouping

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,8 +40,8 @@ Running the above code will result in the following happening:
 
 It is recommended to import the following css files which help normalize styles across browsers:
 
-- The Tailwind reset [available here](https://unpkg.com/tailwindcss@1.7.5/dist/base.min.css)
-- The Tailwind prose helper [available here](https://unpkg.com/@tailwindcss/typography@0.2.0/dist/typography.min.css)
+- The Tailwind reset [available here](https://unpkg.com/tailwindcss/dist/base.min.css)
+- The Tailwind prose helper [available here](https://unpkg.com/@tailwindcss/typography/dist/typography.min.css)
 
 ### Extending the default theme
 
@@ -82,6 +82,22 @@ ow(['bg-red-500', false && 'rounded']);
 // Function call passing an object (keys with falsey values will be omitted)
 ow({ 'bg-red-500': true, rounded: true });
 ow({ 'bg-red-500': true, rounded: false });
+```
+
+### Variant Grouping
+
+Directives with the same variants can be nested using parenthesis. Oceanwind will expand the nested directives; applying the variant to each nested directive before translation. For example:
+
+> Notice any directives within tagged template literals can span multiple lines
+
+```js
+ow`
+  sm:hover:(
+    bg-black
+    text-white
+  )
+  md:(bg-white hover:text-black)
+`;
 ```
 
 ### Catching Errors

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ ow({ 'bg-red-500': true, rounded: false });
 
 ### Variant Grouping
 
-Directives with the same variants can be nested using parenthesis. Oceanwind will expand the nested directives; applying the variant to each nested directive before translation. For example:
+Directives with the same variants can be grouped using parenthesis. Oceanwind will expand the nested directives; applying the variant to each directive in the group before translation. For example:
 
 > Notice any directives within tagged template literals can span multiple lines
 
@@ -99,6 +99,20 @@ ow`
   md:(bg-white hover:text-black)
 `;
 ```
+
+It is possible to nest groupings too, for example:
+
+```js
+ow`
+  sm:(
+    bg-black
+    text-white
+    hover:(bg-white text-black)
+  )
+`;
+```
+
+Two things to note here is that the outermost variant should always be a responsive variant (just like in tailwind `hover:sm:` is not supported) and that nesting responsive variants doesn't make sense either, for example `sm:md:` is not supported.
 
 ### Catching Errors
 

--- a/test/app.js
+++ b/test/app.js
@@ -25,8 +25,6 @@ const ow = themed({
 const style = {
   main: ow`
     ${true ? 'text-green-500' : ''}
-    sm:text-red-500
-    md:text-purple-800
     bg-current
     font-sans
     w-full
@@ -35,6 +33,13 @@ const style = {
     items-center
     justify-center
     clearfix
+    transition
+    duration-1000
+    sm:(
+      hover:bg-blue-600
+      text-blue-500
+    )
+    md:hover:(text-purple-700 bg-purple-500)
   `,
   card: ow`
     bg-white

--- a/test/app.js
+++ b/test/app.js
@@ -36,8 +36,7 @@ const style = {
     transition
     duration-1000
     sm:(
-      hover:bg-blue-600
-      text-blue-500
+      hover:(bg-blue-600 text-blue-500)
     )
     md:hover:(text-purple-700 bg-purple-500)
   `,

--- a/test/module.js
+++ b/test/module.js
@@ -324,10 +324,10 @@ const cases = {
   'scale-50': { transform: `scale(${theme.scale['50']})` },
   'scale-100': { transform: `scale(${theme.scale['100']})` },
 
-  'rotate-0': { transform: `rotate(${theme.rotate['0']}deg)` },
-  'rotate-45': { transform: `rotate(${theme.rotate['45']}deg)` },
-  'rotate-180': { transform: `rotate(${theme.rotate['180']}deg)` },
-  '-rotate-90': { transform: `rotate(-${theme.rotate['90']}deg)` },
+  'rotate-0': { transform: `rotate(${theme.rotate['0']})` },
+  'rotate-45': { transform: `rotate(${theme.rotate['45']})` },
+  'rotate-180': { transform: `rotate(${theme.rotate['180']})` },
+  '-rotate-90': { transform: `rotate(-${theme.rotate['90']})` },
 
   'origin-center': { 'transform-origin': 'center' },
 
@@ -616,6 +616,146 @@ const cases = {
 
   'p-999': { padding: '999ex' },
   'rounded-2xl': { 'border-radius': '2rem' },
+
+  'rotate-45 hover:(bg-red-500)': {
+    transform: `rotate(${theme.rotate['45']})`,
+    ':hover': { 'background-color': theme.colors['red']['500'] },
+  },
+
+  'rotate-45 hover:(bg-red-500 text-blue-500)': {
+    transform: `rotate(${theme.rotate['45']})`,
+    ':hover': {
+      'background-color': theme.colors['red']['500'],
+      color: theme.colors['blue']['500'],
+    },
+  },
+
+  'rotate-45 sm:hover:(bg-red-500)': {
+    transform: `rotate(${theme.rotate['45']})`,
+    '@media': {
+      [`(min-width: ${theme.screens['sm']})`]: {
+        ':hover': {
+          'background-color': theme.colors['red']['500'],
+        },
+      },
+    },
+  },
+
+  'rotate-45 sm:hover:(bg-red-500 text-blue-500)': {
+    transform: `rotate(${theme.rotate['45']})`,
+    '@media': {
+      [`(min-width: ${theme.screens['sm']})`]: {
+        ':hover': {
+          'background-color': theme.colors['red']['500'],
+          color: theme.colors['blue']['500'],
+        },
+      },
+    },
+  },
+
+  [`sm:(rotate-45 hover:(bg-red-500))`]: {
+    '@media': {
+      [`(min-width: ${theme.screens['sm']})`]: {
+        transform: `rotate(${theme.rotate['45']})`,
+        ':hover': {
+          'background-color': theme.colors['red']['500'],
+        },
+      },
+    },
+  },
+
+  [`sm:(rotate-45 hover:(bg-red-500 text-blue-500))`]: {
+    '@media': {
+      [`(min-width: ${theme.screens['sm']})`]: {
+        transform: `rotate(${theme.rotate['45']})`,
+        ':hover': {
+          'background-color': theme.colors['red']['500'],
+          color: theme.colors['blue']['500'],
+        },
+      },
+    },
+  },
+
+  [`sm:(
+      rotate-45
+      hover:(bg-red-500)
+    )`]: {
+    '@media': {
+      [`(min-width: ${theme.screens['sm']})`]: {
+        transform: `rotate(${theme.rotate['45']})`,
+        ':hover': {
+          'background-color': theme.colors['red']['500'],
+        },
+      },
+    },
+  },
+
+  [`sm:(
+      rotate-45
+      hover:(bg-red-500 text-blue-500)
+    )`]: {
+    '@media': {
+      [`(min-width: ${theme.screens['sm']})`]: {
+        transform: `rotate(${theme.rotate['45']})`,
+        ':hover': {
+          'background-color': theme.colors['red']['500'],
+          color: theme.colors['blue']['500'],
+        },
+      },
+    },
+  },
+
+  [`sm:(
+      rotate-45
+      hover:(
+        bg-red-500
+      )
+    )`]: {
+    '@media': {
+      [`(min-width: ${theme.screens['sm']})`]: {
+        transform: `rotate(${theme.rotate['45']})`,
+        ':hover': {
+          'background-color': theme.colors['red']['500'],
+        },
+      },
+    },
+  },
+
+  [`sm:(
+      rotate-45
+      hover:(
+        bg-red-500
+        text-blue-500
+      )
+    )`]: {
+    transform: `rotate(${theme.rotate['45']})`,
+    '@media': {
+      [`(min-width: ${theme.screens['sm']})`]: {
+        ':hover': {
+          'background-color': theme.colors['red']['500'],
+          color: theme.colors['blue']['500'],
+        },
+      },
+    },
+  },
+
+  [`sm:(
+      rotate-45
+      hover:(
+        bg-red-500
+        text-blue-500
+      )
+    )`]: {
+    '@media': {
+      [`(min-width: ${theme.screens['sm']})`]: {
+        transform: `rotate(${theme.rotate['45']})`,
+        ':hover': {
+          'background-color': theme.colors['red']['500'],
+          color: theme.colors['blue']['500'],
+        },
+      },
+    },
+  },
 };
 
 let failed;

--- a/theme.js
+++ b/theme.js
@@ -481,10 +481,10 @@ export default ({
     150: '1.5',
   },
   rotate: {
-    0: 0,
-    45: 45,
-    90: 90,
-    180: 180,
+    0: '0deg',
+    45: '45deg',
+    90: '90deg',
+    180: '180deg',
   },
   translate: {
     ...spacing,

--- a/translate.js
+++ b/translate.js
@@ -516,7 +516,7 @@ export default (theme) => (str) => {
           out['transform'] = `scale(${theme.scale[i[1]]})`;
           break;
         case 'rotate':
-          out['transform'] = `rotate(${n ? i[1] * -1 : i[1]}deg)`;
+          out['transform'] = `rotate(${n ? '-' : ''}${theme.rotate[i[1]]})`;
           break;
         case 'origin':
           out[`transform-${i[0]}`] = i[1];

--- a/util/normalize.js
+++ b/util/normalize.js
@@ -1,34 +1,43 @@
-const handleVariantGrouping = (prefix) => (acc, x) => {
-  if (prefix) {
-    x = prefix + x;
-    if (x.endsWith(')')) {
-      x = x.slice(0, -1);
-      prefix = null;
-    }
-  } else {
+const handleVariantGrouping = (arr) => {
+  let prefix = [];
+  return arr.reduce((acc, x) => {
     const start = x.match(/(.*:)+\(/);
+    const end = x.match(/\)/g) || [];
+
     if (start) {
-      prefix = start[1];
-      x = start.input.replace('(', '');
+      prefix = prefix.concat(start[1].split('('));
+      x = start.input.replace(start[0], '');
+      console.log(prefix, x);
     }
-  }
-  return x.endsWith(':') ? acc : [...acc, x];
+
+    x = prefix.join('') + x;
+
+    if (end.length > 0) {
+      end.forEach(() => {
+        x = x.slice(0, -1);
+        prefix.pop();
+      });
+    }
+
+    return x.endsWith(':') ? acc : [...acc, x];
+  }, []);
 };
 
 export default (strings, ...values) =>
-  (typeof strings === 'string'
-    ? strings
-    : Array.isArray(strings)
-    ? strings.reduce(
-        (str, rule, i) => (str += [rule || '', values[i] || ''].join(' ')),
-        ''
-      )
-    : Object.entries(strings).reduce(
-        (str, [rule, val]) => (str = [str, val ? rule : ''].join(' ')),
-        ''
-      )
-  )
-    .replace(/\s\s+/g, ' ')
-    .trim()
-    .split(' ')
-    .reduce(handleVariantGrouping(), []);
+  handleVariantGrouping(
+    (typeof strings === 'string'
+      ? strings
+      : Array.isArray(strings)
+      ? strings.reduce(
+          (str, rule, i) => (str += [rule || '', values[i] || ''].join(' ')),
+          ''
+        )
+      : Object.entries(strings).reduce(
+          (str, [rule, val]) => (str = [str, val ? rule : ''].join(' ')),
+          ''
+        )
+    )
+      .replace(/\s\s+/g, ' ')
+      .trim()
+      .split(' ')
+  );

--- a/util/normalize.js
+++ b/util/normalize.js
@@ -7,7 +7,6 @@ const handleVariantGrouping = (arr) => {
     if (start) {
       prefix = prefix.concat(start[1].split('('));
       x = start.input.replace(start[0], '');
-      console.log(prefix, x);
     }
 
     x = prefix.join('') + x;

--- a/util/normalize.js
+++ b/util/normalize.js
@@ -1,3 +1,20 @@
+const handleVariantGrouping = (prefix) => (acc, x) => {
+  if (prefix) {
+    x = prefix + x;
+    if (x.endsWith(')')) {
+      x = x.slice(0, -1);
+      prefix = null;
+    }
+  } else {
+    const start = x.match(/(.*:)+\(/);
+    if (start) {
+      prefix = start[1];
+      x = start.input.replace('(', '');
+    }
+  }
+  return x.endsWith(':') ? acc : [...acc, x];
+};
+
 export default (strings, ...values) =>
   (typeof strings === 'string'
     ? strings
@@ -13,4 +30,5 @@ export default (strings, ...values) =>
   )
     .replace(/\s\s+/g, ' ')
     .trim()
-    .split(' ');
+    .split(' ')
+    .reduce(handleVariantGrouping(), []);


### PR DESCRIPTION
Directives with the same variants can now be nested using parenthesis. Oceanwind will expand the nested directives; applying the variant to each nested directive before translation. For example:

```js
ow`
  sm:hover:(
    bg-black
    text-white
  )
  md:(bg-white hover:text-black)
`;
```

Gets expanded into:

```
sm:hover:bg-black sm:hover:text-white md:bg-white md:hover:text-black
```

It is possible to nest groupings too, for example:

```js
ow`
  sm:(
    bg-black
    text-white
    hover:(bg-white text-black)
  )
`;
```

Two things to note here is that the outermost variant should always be a responsive variant (just like in tailwind `hover:sm:` is not supported) and that nesting responsive variants doesn't make sense either, for example `sm:md:` is not supported.

Syntax inspired by a comment in this article https://dev.to/swyx/why-tailwind-css-2o8f by @sw-yx.