### PR TITLE
refactor: Naming functions

### DIFF
--- a/theme.js
+++ b/theme.js
@@ -175,7 +175,7 @@ export const globals = {
   },
 };
 
-export default ({
+const theme = ({
   screens,
   colors,
   spacing,
@@ -545,3 +545,5 @@ export default ({
     },
   },
 });
+
+export default theme;

--- a/translate.js
+++ b/translate.js
@@ -57,7 +57,7 @@ const hexToRgb = (color) => {
   return `${r},${g},${b}`;
 }
 
-export default (theme) => (str) => {
+const translate = (theme) => (str) => {
   let x;
   let n = '';
 
@@ -911,3 +911,5 @@ export default (theme) => (str) => {
 
   return out;
 };
+
+export default translate;


### PR DESCRIPTION
Removes the following warning message that would show up while using Fast Refresh and other tools alongside Oceanwind:

![temp](https://user-images.githubusercontent.com/33403762/100533592-c9e0b100-31cb-11eb-8e6d-aaef860b991b.png)

As far as I understand Oceanwind isn't getting any sort of benefit from exporting an anonymous function here, though certainly close this if that isn't the case. My knowledge on Fast Refresh and how that works is quite literally limited to this message.