### PR TITLE
Correct types for function call passing an array

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,4 @@
-type Styles = string | TemplateStringsArray | string[] | Record<string, boolean>;
+type Styles = string | TemplateStringsArray | Array<string | boolean> | Record<string, boolean>;
 
 declare function process(theme: Record<string, unknown>): (strings: Styles) => Record<string, unknown>;
 declare function configure(theme: Record<string, unknown>): Record<string, unknown>;

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,4 @@
-type Styles = string | TemplateStringsArray | Array<string | boolean> | Record<string, boolean>;
+type Styles = string | TemplateStringsArray | Array<string | false> | Record<string, boolean>;
 
 declare function process(theme: Record<string, unknown>): (strings: Styles) => Record<string, unknown>;
 declare function configure(theme: Record<string, unknown>): Record<string, unknown>;


### PR DESCRIPTION
Function call passing an array like the example below, falsey items will be omitted, but the types don't reflect that (`string[]`)
```js
ow(['bg-red-500', false && 'rounded']);
```

I originally fixed this by making it accept `Array<string | boolean>`, although `ow([true])` will result in `"true"`.

I'm quite new to TS, but I guess to include all falsey values I could make it `Array<string | false | "" | 0 | NaN |  null | undefined>`, but that seems too much and new falsey type could be added (eg. BigInt: `!!0n === false`).

Typescript normally prefers being explicit so consumers can convert falsey values to boolean (`!!`).

So `Array<string | false>` seems like the best solution.

Also, thanks for the great and interesting library, I used it to convert a CRA styled-components app to tailwind without having to set up all the tailwind processing, plus I'm not sure CRA supports Tailwind out-of-the-box.